### PR TITLE
MPC Demo Changes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,7 @@ datasource db {
 
 model User {
   id             Int     @id @default(autoincrement())
-  walletId       String
+  walletId       String?
   exchangeUserId Int
   clientApiKey   String?
   username       String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ model User {
   walletId       String?
   exchangeUserId Int
   clientApiKey   String?
+  backupShare    String?
   username       String
   apiSecret      String?
   apiKey         String?

--- a/src/libs/PortalApi.ts
+++ b/src/libs/PortalApi.ts
@@ -11,14 +11,13 @@ class PortalApi {
    *
    * @returns clientApiKey
    */
-  async getClientApiKey(address: string): Promise<string> {
+  async getClientApiKey(username: string): Promise<string> {
     console.info(
-      `Requesting Client API Key from Connect API for address: ${address}`
+      `Requesting Client API Key from Connect API for user: ${username}`
     )
     return await axios
       .post(
         `${PORTAL_API_URL}/api/clients`,
-        { address },
         {
           headers: {
             Authorization: `Bearer ${this.apiKey}`,

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ import { PrismaClient } from '@prisma/client'
 import HotWalletService from './services/HotWalletService'
 import WalletService from './services/WalletService'
 import { EXCHANGE_WALLET_ADDRESS, EXCHANGE_WALLET_PRIVATE_KEY } from './config'
-import { Wallet as EthersWallet } from 'ethers'
+import { ethers, Wallet as EthersWallet } from 'ethers'
 import { signTypedData_v4 } from "eth-sig-util";
 
 const app: Application = express()
@@ -50,21 +50,10 @@ app.post(
   }
 )
 
-app.get('/mobile/:exchangeUserId/address', async (req: any, res: any) => {
-  await mobileService.sendAddress(req, res)
-})
-
-app.post('/mobile/:exchangeUserId/token', async (req: any, res: any) => {
-  await mobileService.addPushToken(req, res)
-})
-
 app.post('/mobile/:exchangeUserId/transfer', async (req: any, res: any) => {
   await mobileService.transferFunds(req, res)
 })
 
-app.get('/mobile/:exchangeUserId/walletId', async (req: any, res: any) => {
-  await mobileService.sendWalletId(req, res)
-})
 
 app.post('/webhook', async (req, res) => {
   try {    

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,6 +54,9 @@ app.post('/mobile/:exchangeUserId/transfer', async (req: any, res: any) => {
   await mobileService.transferFunds(req, res)
 })
 
+app.post('/webhook/backup', async (req: any, res: any) => {
+  await mobileService.storeBackupShare(req, res)
+})
 
 app.post('/webhook', async (req, res) => {
   try {    

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -183,6 +183,34 @@ class MobileService {
     }
   }
 
+    /*
+     * Store the backup Share in the portalEx database.
+     */
+    async storeBackupShare(req: any, res: any): Promise<void> {
+      try {
+        const clientApiKey = req.params['clientApiKey']
+        const backupShare = String(req.body['backupShare'])
+
+        const user = await this.getUserByClientApiKey(clientApiKey)
+
+        await this.prisma.user.update({
+          where: {
+            id: user.id,
+          },
+          data: {
+            backupShare: backupShare,
+          },
+        })
+        res
+        .status(200)
+        .send(`Successfully stored backup share for client`)
+    } catch (error) {
+      console.error(error)
+      res.status(500).send('Unknown server error')
+    }
+
+    }
+
   /*
    * Transfers an amount of eth from the exchange to the users wallet.
    */
@@ -346,6 +374,21 @@ class MobileService {
     return user
   }
 
+/*
+   * Gets user object based on clientApiKey
+   */
+private async getUserByClientApiKey(clientApiKey: string) {
+  console.info(`Querying for userId: ${clientApiKey}`)
+  const user = await this.prisma.user.findFirst({
+    where: { clientApiKey },
+  })
+
+  if (!user) {
+    throw new EntityNotFoundError('User', "clientApiKey")
+  }
+
+  return user
+}  
 
   /*
    * Transfers an amount of funds from the omnibus to a specific "to" address.


### PR DESCRIPTION
- changes the signup/login endpoints not to send the address to connect api
- no longer create a wallet on signup
- adds backupShare to the user data model
- adds a `webhook/backup` endpoint to store the backup share
- uses clientApiKey to store the backup share (we should probably use a clientId or some other way to let the webhook know which user the share belongs to)