### PR TITLE
Fix to ExchangeId Problem

### DIFF
--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -118,21 +118,27 @@ class MobileService {
         return
       }
 
-      const exchangeUserId = Math.floor(Math.random() * 1000000)
-      const existingExchangeUser = await this.getUserByExchangeId(
-        exchangeUserId
-      ).catch((error) => {
-        if (error instanceof EntityNotFoundError) {
-          return null
-        }
-        throw error
-      })
+      // idk why we have this exchangeUserId, but it needs to be a unique random number
+      let attempt = 0
+      const maxAttempts = 5
+      let exchangeUserId = 0
+      let userAlreadyExists = true
 
-      if (existingExchangeUser) {
-        res
-          .status(400)
-          .json({ message: 'User already exists with user id, try again' })
-        return
+      while (userAlreadyExists) {
+        if (attempt > maxAttempts) {
+          throw new Error('Failed to create user. Could not generate unique id. Try again.')
+        }
+
+        exchangeUserId = Math.floor(Math.random() * 100000000)
+        console.info(`Attempting to create user with exchangeUserId: ${exchangeUserId}`)
+        await this.getUserByExchangeId(
+          exchangeUserId
+        ).catch((error) => {
+          if (error instanceof EntityNotFoundError) {
+            userAlreadyExists = false
+          }
+        })
+        attempt++
       }
 
       console.info(`Calling portal to create a client api key`)
@@ -166,7 +172,7 @@ class MobileService {
   }
 
   async createUser(username: string, isAccountAbstracted: boolean) {
-    const exchangeUserId = Math.floor(Math.random() * 1000000)
+    const exchangeUserId = Math.floor(Math.random() * 100000000)
     const existingExchangeUser = await this.getUserByExchangeId(
       exchangeUserId
     ).catch((error) => {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
Dumb fix for the problem of unique exchangeUserIds.
- increases the max random number to 100M from 1M
- adds 5 attempts if the ids already been used
- throws error if that fails.

## Details

### Code
- Checked against coding style guide: Yes|No
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: Yes|No|Pending
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: Yes|No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: Yes|No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: Yes|No
- Changelog updated: Yes|No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
