### PR TITLE
Kelsonic/eng 1781 update how portalex is getting the backup share from the db

### DIFF
--- a/prisma/migrations/20231114221008_make_client_id_unique/migration.sql
+++ b/prisma/migrations/20231114221008_make_client_id_unique/migration.sql
@@ -1,0 +1,60 @@
+-- Example data:
+-- INSERT INTO "User"
+--     (walletId, exchangeUserId, cipherText, clientApiKey, clientId, backupShare, username, apiSecret, apiKey, address, pushToken)
+-- VALUES
+--     ('walletId1', 1, 'cipherText1', 'clientApiKey1', 'clientId1', 'backupShare1', 'username1', 'apiSecret1', 'apiKey1', 'address1', 'pushToken1'),
+--     ('walletId2', 1, 'cipherText2', 'clientApiKey2', 'clientId1', 'backupShare2', 'username1', 'apiSecret2', 'apiKey2', 'address2', 'pushToken2'),
+--     ('walletId3', 2, 'cipherText3', 'clientApiKey3', 'clientId2', 'backupShare3', 'username2', 'apiSecret3', 'apiKey3', 'address3', 'pushToken3'),
+--     ('walletId4', 2, 'cipherText4', 'clientApiKey4', 'clientId2', 'backupShare4', 'username2', 'apiSecret4', 'apiKey4', 'address4', 'pushToken4');
+
+-- Find all users that have either duplicate clientId, duplicate exchangeUserId, or duplicate username, and delete all but one of them (the one with the lowest id).
+DELETE FROM "User"
+WHERE id NOT IN (
+    SELECT MIN(id)
+    FROM "User"
+    GROUP BY clientId
+    HAVING COUNT(*) > 1
+)
+AND clientId IN (
+    SELECT clientId
+    FROM "User"
+    GROUP BY clientId
+    HAVING COUNT(*) > 1
+);
+
+DELETE FROM "User"
+WHERE id NOT IN (
+    SELECT MIN(id)
+    FROM "User"
+    GROUP BY exchangeUserId
+    HAVING COUNT(*) > 1
+)
+AND exchangeUserId IN (
+    SELECT exchangeUserId
+    FROM "User"
+    GROUP BY exchangeUserId
+    HAVING COUNT(*) > 1
+);
+
+DELETE FROM "User"
+WHERE id NOT IN (
+    SELECT MIN(id)
+    FROM "User"
+    GROUP BY username
+    HAVING COUNT(*) > 1
+)
+AND username IN (
+    SELECT username
+    FROM "User"
+    GROUP BY username
+    HAVING COUNT(*) > 1
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_clientId_key" ON "User"("clientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_exchangeUserId_key" ON "User"("exchangeUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");

--- a/prisma/migrations/20231114221008_make_client_id_unique/migration.sql
+++ b/prisma/migrations/20231114221008_make_client_id_unique/migration.sql
@@ -1,24 +1,31 @@
 -- Example data:
 -- INSERT INTO "User"
---     (walletId, exchangeUserId, cipherText, clientApiKey, clientId, backupShare, username, apiSecret, apiKey, address, pushToken)
+--     ("walletId", "exchangeUserId", "cipherText", "clientApiKey", "clientId", "backupShare", "username", "apiSecret", "apiKey", "address", "pushToken")
 -- VALUES
---     ('walletId1', 1, 'cipherText1', 'clientApiKey1', 'clientId1', 'backupShare1', 'username1', 'apiSecret1', 'apiKey1', 'address1', 'pushToken1'),
---     ('walletId2', 1, 'cipherText2', 'clientApiKey2', 'clientId1', 'backupShare2', 'username1', 'apiSecret2', 'apiKey2', 'address2', 'pushToken2'),
---     ('walletId3', 2, 'cipherText3', 'clientApiKey3', 'clientId2', 'backupShare3', 'username2', 'apiSecret3', 'apiKey3', 'address3', 'pushToken3'),
---     ('walletId4', 2, 'cipherText4', 'clientApiKey4', 'clientId2', 'backupShare4', 'username2', 'apiSecret4', 'apiKey4', 'address4', 'pushToken4');
+--     -- Duplicate "clientId"
+--     ('walletId1', 1, 'cipherText1', 'clientApiKey1', 'clientId1', 'backupShare1', 'username1', 'apiSecret1', 'apiKey1', 'address1', 'pushToken1'), -- id: 1
+--     ('walletId2', 2, 'cipherText2', 'clientApiKey2', 'clientId1', 'backupShare2', 'username2', 'apiSecret2', 'apiKey2', 'address2', 'pushToken2'), -- id: 2
+--     -- Duplicate "exchangeUserId"
+--     ('walletId3', 3, 'cipherText3', 'clientApiKey3', 'clientId3', 'backupShare3', 'username3', 'apiSecret3', 'apiKey3', 'address3', 'pushToken3'), -- id: 3
+--     ('walletId4', 3, 'cipherText4', 'clientApiKey4', 'clientId4', 'backupShare4', 'username4', 'apiSecret4', 'apiKey4', 'address4', 'pushToken4'), -- id: 4
+--     -- Duplicate "username"
+--     ('walletId5', 5, 'cipherText5', 'clientApiKey5', 'clientId5', 'backupShare5', 'username5', 'apiSecret5', 'apiKey5', 'address5', 'pushToken5'), -- id: 5
+--     ('walletId6', 6, 'cipherText6', 'clientApiKey6', 'clientId6', 'backupShare6', 'username5', 'apiSecret6', 'apiKey6', 'address6', 'pushToken6'); -- id: 6
+-- After the migration, the following IDs should be kept: 1, 3, 5
+-- After the migration, the following IDs should be deleted: 2, 4, 6
 
--- Find all users that have either duplicate clientId, duplicate exchangeUserId, or duplicate username, and delete all but one of them (the one with the lowest id).
+-- Find all users that have either duplicate "clientId", duplicate "exchangeUserId", or duplicate "username", and delete all but one of them (the one with the lowest id).
 DELETE FROM "User"
 WHERE id NOT IN (
     SELECT MIN(id)
     FROM "User"
-    GROUP BY clientId
+    GROUP BY "clientId"
     HAVING COUNT(*) > 1
 )
-AND clientId IN (
-    SELECT clientId
+AND "clientId" IN (
+    SELECT "clientId"
     FROM "User"
-    GROUP BY clientId
+    GROUP BY "clientId"
     HAVING COUNT(*) > 1
 );
 
@@ -26,13 +33,13 @@ DELETE FROM "User"
 WHERE id NOT IN (
     SELECT MIN(id)
     FROM "User"
-    GROUP BY exchangeUserId
+    GROUP BY "exchangeUserId"
     HAVING COUNT(*) > 1
 )
-AND exchangeUserId IN (
-    SELECT exchangeUserId
+AND "exchangeUserId" IN (
+    SELECT "exchangeUserId"
     FROM "User"
-    GROUP BY exchangeUserId
+    GROUP BY "exchangeUserId"
     HAVING COUNT(*) > 1
 );
 
@@ -40,13 +47,13 @@ DELETE FROM "User"
 WHERE id NOT IN (
     SELECT MIN(id)
     FROM "User"
-    GROUP BY username
+    GROUP BY "username"
     HAVING COUNT(*) > 1
 )
-AND username IN (
-    SELECT username
+AND "username" IN (
+    SELECT "username"
     FROM "User"
-    GROUP BY username
+    GROUP BY "username"
     HAVING COUNT(*) > 1
 );
 

--- a/prisma/migrations/20231115185042_make_client_id_required/migration.sql
+++ b/prisma/migrations/20231115185042_make_client_id_required/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Made the column `clientId` on table `User` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- Delete all user records with a null clientId
+DELETE FROM "User" WHERE "clientId" IS NULL;
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "clientId" SET NOT NULL;

--- a/prisma/migrations/20231115190513_make_client_api_key_required/migration.sql
+++ b/prisma/migrations/20231115190513_make_client_api_key_required/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[clientApiKey]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+  - Made the column `clientApiKey` on table `User` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- Delete users without clientApiKey (only 2 on staging).
+DELETE FROM "User" WHERE "clientApiKey" IS NULL;
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "clientApiKey" SET NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_clientApiKey_key" ON "User"("clientApiKey");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,8 +12,8 @@ model User {
   walletId       String?
   exchangeUserId Int     @unique
   cipherText     String?
-  clientApiKey   String?
-  clientId       String? @unique
+  clientApiKey   String  @unique
+  clientId       String  @unique
   backupShare    String?
   username       String  @unique
   apiSecret      String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,16 +7,15 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-
 model User {
   id             Int     @id @default(autoincrement())
   walletId       String?
-  exchangeUserId Int
+  exchangeUserId Int     @unique
   cipherText     String?
   clientApiKey   String?
-  clientId       String?
+  clientId       String? @unique
   backupShare    String?
-  username       String
+  username       String  @unique
   apiSecret      String?
   apiKey         String?
   address        String?

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -277,9 +277,15 @@ class MobileService {
       const backupShare = String(req.body['share'])
       console.info(`Storing backup share for client ${clientId}`)
 
-      if (!clientId || !backupShare) {
-        throw new Error('MPC processor did not send the API Key or Share')
+      if (!clientId) {
+        console.error('[storeBackupShare] Did not receive clientId')
+        throw new Error('[storeBackupShare] Did not receive clientId')
       }
+      if (!backupShare) {
+        console.error('[storeBackupShare] Did not receive backup share')
+        throw new Error('[storeBackupShare] Did not receive backup share')
+      }
+
       const user = await this.getUserByClientId(clientId)
 
       await this.prisma.user.update({
@@ -308,11 +314,15 @@ class MobileService {
     try {
       const clientId = req.body['clientId']
       if (!clientId) {
-        throw new Error('Did not receive clientId')
+        console.error('[getBackupShare] Did not receive clientId')
+        throw new Error('[getBackupShare] Did not receive clientId')
       }
 
       const user = await this.getUserByClientId(clientId)
       if (!user?.backupShare) {
+        console.info(
+          `User ${clientId} does not have a backup share stored in the database`
+        )
         res.status(400).json({ message: 'User does not have a backup share' })
         return
       }

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -287,7 +287,7 @@ class MobileService {
           id: user.id,
         },
         data: {
-          backupShare: backupShare,
+          backupShare,
         },
       })
 
@@ -464,7 +464,7 @@ class MobileService {
   private async getUserByUsername(username: string): Promise<User> {
     console.info(`Querying for user by username: ${username}`)
 
-    const user = await this.prisma.user.findFirst({
+    const user = await this.prisma.user.findUnique({
       where: { username },
     })
 
@@ -480,7 +480,7 @@ class MobileService {
    */
   private async getUserByExchangeId(exchangeUserId: number) {
     console.info(`Querying for userId: ${exchangeUserId}`)
-    const user = await this.prisma.user.findFirst({
+    const user = await this.prisma.user.findUnique({
       where: { exchangeUserId },
     })
 
@@ -496,7 +496,7 @@ class MobileService {
    */
   private async getUserByClientId(clientId: string) {
     console.info(`Querying for userId: ${clientId}`)
-    const user = await this.prisma.user.findFirst({
+    const user = await this.prisma.user.findUnique({
       where: { clientId },
     })
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR makes `clientId`, `exchangeUserId`, `username`, and `clientApiKey` unique and required. Any duplicates found, it keeps only the oldest one (the record with the lowest `id` value).

This PR then updates our user db find queries to only use `findUnique` instead of `findFirst`.

```sql
-- Example data:
INSERT INTO "User"
    ("walletId", "exchangeUserId", "cipherText", "clientApiKey", "clientId", "backupShare", "username", "apiSecret", "apiKey", "address", "pushToken")
VALUES
    -- Duplicate "clientId"
    ('walletId1', 1, 'cipherText1', 'clientApiKey1', 'clientId1', 'backupShare1', 'username1', 'apiSecret1', 'apiKey1', 'address1', 'pushToken1'), -- id: 1
    ('walletId2', 2, 'cipherText2', 'clientApiKey2', 'clientId1', 'backupShare2', 'username2', 'apiSecret2', 'apiKey2', 'address2', 'pushToken2'), -- id: 2
    -- Duplicate "exchangeUserId"
    ('walletId3', 3, 'cipherText3', 'clientApiKey3', 'clientId3', 'backupShare3', 'username3', 'apiSecret3', 'apiKey3', 'address3', 'pushToken3'), -- id: 3
    ('walletId4', 3, 'cipherText4', 'clientApiKey4', 'clientId4', 'backupShare4', 'username4', 'apiSecret4', 'apiKey4', 'address4', 'pushToken4'), -- id: 4
    -- Duplicate "username"
    ('walletId5', 5, 'cipherText5', 'clientApiKey5', 'clientId5', 'backupShare5', 'username5', 'apiSecret5', 'apiKey5', 'address5', 'pushToken5'), -- id: 5
    ('walletId6', 6, 'cipherText6', 'clientApiKey6', 'clientId6', 'backupShare6', 'username5', 'apiSecret6', 'apiKey6', 'address6', 'pushToken6'); -- id: 6
-- After the migration, the following IDs should be kept: 1, 3, 5
-- After the migration, the following IDs should be deleted: 2, 4, 6
```

## Visuals
<!-- Attach screenshots or videos of any visual changes. If none, delete this section. -->

### Before migration
<img width="1164" alt="Screenshot 2023-11-15 at 12 09 43 AM" src="https://github.com/portal-hq/portalex/assets/12773166/59e5352c-adb6-4cf0-9077-28b75a820fc4">

### After migration
<img width="1157" alt="Screenshot 2023-11-15 at 12 09 50 AM" src="https://github.com/portal-hq/portalex/assets/12773166/bf182e50-4cee-4d50-9471-4b433e0c1ab9">


## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: Yes
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
Migration is automated, only oldest duplicate user records will be kept alive (newest assumed corrupted).
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
