### PR TITLE
Adding new endpoint to get org share

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -175,6 +175,13 @@ app.post('/mobile/:exchangeUserId/transfer', async (req: any, res: any) => {
 })
 
 app.get(
+  '/mobile/:exchangeUserId/org-share/fetch',
+  async (req: any, res: any) => {
+    await mobileService.getOrgShare(req, res)
+  }
+)
+
+app.get(
   '/mobile/:exchangeUserId/cipher-text/fetch',
   async (req: any, res: any) => {
     await mobileService.getCipherText(req, res)

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -249,6 +249,25 @@ class MobileService {
   }
 
   /*
+   * Get the org share from the portalEx database for the specific user.
+   */
+  async getOrgShare(req: any, res: any): Promise<void> {
+    try {
+      const exchangeUserId = Number(req.params['exchangeUserId'])
+      const user = await this.getUserByExchangeId(exchangeUserId)
+
+      if (!user.backupShare) {
+        throw new Error('User does not have a stored org share')
+      }
+
+      res.status(200).json({ orgShare: user.backupShare })
+    } catch (error) {
+      console.error(error)
+      res.status(500).json({ message: 'Internal server error' })
+    }
+  }
+
+  /*
    * Get the cipher text from the portalEx database.
    */
   async getCipherText(req: any, res: any): Promise<void> {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR adds `/mobile/:exchangeUserId/org-share/fetch` to PortalEx to be used by the eject functionality. 

## Visuals
<!-- Attach screenshots or videos of any visual changes. If none, delete this section. -->
Postman screenshot of working in Staging:

![Screenshot 2024-01-12 at 2 34 04 PM](https://github.com/portal-hq/portalex/assets/11202447/35ef9826-d0fc-439e-a3d4-414112ba3c35)

E2E tests, note that V5 is failing due to ongoing change with Jukka:
![Screenshot 2024-01-12 at 2 34 46 PM](https://github.com/portal-hq/portalex/assets/11202447/c6a8d795-ff54-4f05-8ee9-52b6599c6c7a)

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Yes
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Yes
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
