### PR TITLE
Update webhooks to support v6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
   "cSpell.words": [
     "arbitrum",
+    "fkey",
+    "pkey",
     "SENDGRID",
     "sepolia"
   ]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "exec": "./node_modules/.bin/ts-node --files ./src/server.ts"
   },
   "dependencies": {
-    "@prisma/client": "^5.7.0",
+    "@prisma/client": "^5.8.1",
     "axios": "^1.5.0",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
@@ -46,7 +46,7 @@
     "jest": "^27.5.1",
     "nodemon": "^2.0.15",
     "prettier": "^2.5.1",
-    "prisma": "^5.7.0",
+    "prisma": "^5.8.1",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.5.0",
     "ts-node-dev": "^1.0.0-pre.44",

--- a/prisma/migrations/20240117230925_add_backup_shares/migration.sql
+++ b/prisma/migrations/20240117230925_add_backup_shares/migration.sql
@@ -1,0 +1,55 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `backupShare` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the column `cipherText` on the `User` table. All the data in the column will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "BackupMethod" AS ENUM ('CUSTOM', 'GDRIVE', 'ICLOUD', 'PASSWORD', 'PASSKEY', 'UNKNOWN');
+
+-- CreateTable
+CREATE TABLE "ClientBackupShare" (
+    "backupMethod" "BackupMethod" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "id" TEXT NOT NULL,
+    "cipherText" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "ClientBackupShare_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CustodianBackupShare" (
+    "backupMethod" "BackupMethod" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "id" TEXT NOT NULL,
+    "share" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "CustodianBackupShare_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ClientBackupShare_userId_key" ON "ClientBackupShare"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CustodianBackupShare_userId_key" ON "CustodianBackupShare"("userId");
+
+-- AddForeignKey
+ALTER TABLE "ClientBackupShare" ADD CONSTRAINT "ClientBackupShare_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CustodianBackupShare" ADD CONSTRAINT "CustodianBackupShare_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Add all User.backupShare to CustodianBackupShare.
+INSERT INTO "CustodianBackupShare" ("backupMethod", "createdAt", "id", "share", "userId")
+SELECT 'UNKNOWN', NOW(), "id", "backupShare", "id" FROM "User";
+
+-- Add all User.cipherText to ClientBackupShare.
+INSERT INTO "ClientBackupShare" ("backupMethod", "createdAt", "id", "cipherText", "userId")
+SELECT 'UNKNOWN', NOW(), "id", "cipherText", "id" FROM "User";
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "backupShare",
+DROP COLUMN "cipherText";

--- a/prisma/migrations/20240117230925_add_backup_shares/migration.sql
+++ b/prisma/migrations/20240117230925_add_backup_shares/migration.sql
@@ -44,11 +44,11 @@ ALTER TABLE "CustodianBackupShare" ADD CONSTRAINT "CustodianBackupShare_userId_f
 
 -- Add all User.backupShare to CustodianBackupShare.
 INSERT INTO "CustodianBackupShare" ("backupMethod", "createdAt", "id", "share", "userId")
-SELECT 'UNKNOWN', NOW(), "id", "backupShare", "id" FROM "User";
+SELECT 'UNKNOWN', NOW(), "id", "backupShare", "id" FROM "User" WHERE "backupShare" IS NOT NULL;
 
 -- Add all User.cipherText to ClientBackupShare.
 INSERT INTO "ClientBackupShare" ("backupMethod", "createdAt", "id", "cipherText", "userId")
-SELECT 'UNKNOWN', NOW(), "id", "cipherText", "id" FROM "User";
+SELECT 'UNKNOWN', NOW(), "id", "cipherText", "id" FROM "User" WHERE "cipherText" IS NOT NULL;
 
 -- AlterTable
 ALTER TABLE "User" DROP COLUMN "backupShare",

--- a/prisma/migrations/20240118224953_update_uniqueness_on_backup_shares/migration.sql
+++ b/prisma/migrations/20240118224953_update_uniqueness_on_backup_shares/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - The `backupMethod` column on the `ClientBackupShare` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `backupMethod` column on the `CustodianBackupShare` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - A unique constraint covering the columns `[userId,backupMethod]` on the table `ClientBackupShare` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[userId,backupMethod]` on the table `CustodianBackupShare` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "ClientBackupShare_userId_key";
+
+-- DropIndex
+DROP INDEX "CustodianBackupShare_userId_key";
+
+-- AlterTable
+ALTER TABLE "ClientBackupShare" DROP COLUMN "backupMethod",
+ADD COLUMN     "backupMethod" TEXT NOT NULL DEFAULT 'UNKNOWN';
+
+-- AlterTable
+ALTER TABLE "CustodianBackupShare" DROP COLUMN "backupMethod",
+ADD COLUMN     "backupMethod" TEXT NOT NULL DEFAULT 'UNKNOWN';
+
+-- DropEnum
+DROP TYPE "BackupMethod";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ClientBackupShare_userId_backupMethod_key" ON "ClientBackupShare"("userId", "backupMethod");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CustodianBackupShare_userId_backupMethod_key" ON "CustodianBackupShare"("userId", "backupMethod");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,43 +7,74 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
-  id             Int     @id @default(autoincrement())
-  walletId       String?
-  exchangeUserId Int     @unique
-  cipherText     String?
-  clientApiKey   String  @unique
-  clientId       String  @unique
-  backupShare    String?
-  username       String  @unique
-  apiSecret      String?
-  apiKey         String?
-  address        String?
-  pushToken      String?
-  wallet         Wallet?
+enum BackupMethod {
+  CUSTOM
+  GDRIVE
+  ICLOUD
+  PASSWORD
+  PASSKEY
+  UNKNOWN
+}
+
+model ClientBackupShare {
+  backupMethod BackupMethod
+  createdAt    DateTime     @default(now())
+  id           String       @id @default(cuid())
+  cipherText   String
+  userId       Int          @unique
+
+  user User @relation(fields: [userId], references: [id])
+}
+
+model CustodianBackupShare {
+  backupMethod BackupMethod
+  createdAt    DateTime     @default(now())
+  id           String       @id @default(cuid())
+  share        String
+  userId       Int          @unique
+
+  user User @relation(fields: [userId], references: [id])
+}
+
+model ExchangeBalance {
+  cachedBalance Decimal @default(0)
+  chainId       Int     @default(4)
+  id            Int     @id @default(autoincrement())
+
+  @@map("exchange_balance")
 }
 
 model MagicCode {
-  id        Int     @id @default(autoincrement())
   code      String
-  email     String
   createdAt DateTime @default(now())
+  email     String
+  id        Int      @id @default(autoincrement())
+}
+
+model User {
+  address        String?
+  apiKey         String?
+  apiSecret      String?
+  clientApiKey   String  @unique
+  clientId       String  @unique
+  exchangeUserId Int     @unique
+  id             Int     @id @default(autoincrement())
+  pushToken      String?
+  username       String  @unique
+  walletId       String?
+
+  clientBackupShares    ClientBackupShare[]
+  custodianBackupShares CustodianBackupShare[]
+  wallet                Wallet?
 }
 
 model Wallet {
   id         String @id @default(cuid())
-  publicKey  String
   privateKey String
-  user       User?  @relation(fields: [userId], references: [id])
+  publicKey  String
   userId     Int?   @unique
 
+  user User? @relation(fields: [userId], references: [id])
+
   @@map("wallets")
-}
-
-model ExchangeBalance {
-  id            Int     @id @default(autoincrement())
-  cachedBalance Decimal @default(0)
-  chainId       Int     @default(4)
-
-  @@map("exchange_balance")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,33 +7,28 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-enum BackupMethod {
-  CUSTOM
-  GDRIVE
-  ICLOUD
-  PASSWORD
-  PASSKEY
-  UNKNOWN
-}
-
 model ClientBackupShare {
-  backupMethod BackupMethod
+  backupMethod String       @default("UNKNOWN")
   createdAt    DateTime     @default(now())
   id           String       @id @default(cuid())
   cipherText   String
-  userId       Int          @unique
+  userId       Int
 
   user User @relation(fields: [userId], references: [id])
+
+  @@unique([userId, backupMethod])
 }
 
 model CustodianBackupShare {
-  backupMethod BackupMethod
+  backupMethod String       @default("UNKNOWN")
   createdAt    DateTime     @default(now())
   id           String       @id @default(cuid())
   share        String
-  userId       Int          @unique
+  userId       Int
 
   user User @relation(fields: [userId], references: [id])
+
+  @@unique([userId, backupMethod])
 }
 
 model ExchangeBalance {

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -270,7 +270,7 @@ class MobileService {
   async getClientBackupShare(req: any, res: any): Promise<void> {
     try {
       const exchangeUserId = Number(req.params['exchangeUserId'])
-      const backupMethod = req.query.backupMethod
+      const backupMethod = req.query.backupMethod || 'UNKNOWN'
 
       const user = await this.getUserByExchangeId(exchangeUserId)
 
@@ -278,6 +278,14 @@ class MobileService {
       const clientBackupShare = user.clientBackupShares?.find(
         (clientBackupShare) => clientBackupShare.backupMethod === backupMethod
       )
+
+      // If no client backup share was found, return a 404.
+      if (!clientBackupShare) {
+        console.error(
+          `[getClientBackupShare] Could not find client backup share for user ${exchangeUserId} with backup method ${backupMethod}]`
+        )
+        res.status(404).json({ message: 'Client backup share not found' })
+      }
 
       res.status(200).json({ cipherText: clientBackupShare?.cipherText })
     } catch (error) {
@@ -353,7 +361,7 @@ class MobileService {
   async getCustodianBackupShare(req: any, res: any): Promise<void> {
     try {
       const exchangeUserId = Number(req.params['exchangeUserId'])
-      const backupMethod = req.query.backupMethod
+      const backupMethod = req.query.backupMethod || 'UNKNOWN'
 
       const user = await this.getUserByExchangeId(exchangeUserId)
 
@@ -361,6 +369,14 @@ class MobileService {
       const custodianBackupShare = user.custodianBackupShares?.find(
         (backupShare) => backupShare.backupMethod === backupMethod
       )
+
+      // If no custodian backup share was found, return a 404.
+      if (!custodianBackupShare) {
+        console.error(
+          `[getCustodianBackupShare] Could not find custodian backup share for user ${exchangeUserId} with backup method ${backupMethod}]`
+        )
+        res.status(404).json({ message: 'Custodian backup share not found' })
+      }
 
       res.status(200).json({ orgShare: custodianBackupShare?.share })
     } catch (error) {

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -225,7 +225,7 @@ class MobileService {
    */
   async storeClientBackupShare(req: any, res: any): Promise<void> {
     try {
-      const backupMethod = req.body['backupMethod']
+      const backupMethod = req.body['backupMethod'] || 'UNKNOWN'
       const cipherText = String(req.body['cipherText'])
       const exchangeUserId = Number(req.params['exchangeUserId'])
 

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -275,11 +275,11 @@ class MobileService {
       const user = await this.getUserByExchangeId(exchangeUserId)
 
       // Attempt to find the client backup share for the specified backup method.
-      const cipherText = user.clientBackupShares?.find(
+      const clientBackupShare = user.clientBackupShares?.find(
         (clientBackupShare) => clientBackupShare.backupMethod === backupMethod
       )
 
-      res.status(200).json({ cipherText })
+      res.status(200).json({ cipherText: clientBackupShare?.cipherText })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -399,20 +399,19 @@ class MobileService {
       const user = await this.getUserByClientId(clientId)
 
       // Obtain the custodian backup shares for the user.
-      const backupShares = user.custodianBackupShares.map(
-        (backupShare) => backupShare.share
-      )
-
-      // const legacyBackupShare = user.custodianBackupShares.find(
-      //   (backupShare) => backupShare.backupMethod === 'UNKNOWN'
-      // )?.share
+      // const backupShares = user.custodianBackupShares.map(
+      //   (backupShare) => backupShare.share
+      // )
+      const legacyBackupShare = user.custodianBackupShares.find(
+        (backupShare) => backupShare.backupMethod === 'UNKNOWN'
+      )?.share
 
       // Return the custodian backup shares for the user.
       console.info(
         `Successfully responded with custodian backup shares for client ${clientId}`
       )
-      // res.status(200).json({ backupShare: legacyBackupShare })
-      res.status(200).json({ backupShares })
+      // res.status(200).json({ backupShares })
+      res.status(200).json({ backupShare: legacyBackupShare })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -298,7 +298,6 @@ class MobileService {
    * Store the custodian backup share for a user.
    */
   async storeCustodianBackupShare(req: any, res: any): Promise<void> {
-    console.log('req.body', req.body)
     try {
       // Obtain the clientId from the request body.
       const clientId = req.body['clientId']

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -310,13 +310,13 @@ class MobileService {
         )
       }
 
-      const backupMethod = req.body['backupMethod']
-      if (!backupMethod) {
+      const backupMethod = req.body['backupMethod'] || 'UNKNOWN'
+      if (typeof backupMethod !== 'string') {
         console.error(
-          '[storeCustodianBackupShare] Received invalid backup method'
+          '[storeCustodianBackupShare] Did not receive backup method as a string'
         )
         throw new Error(
-          '[storeCustodianBackupShare] Received invalid backup method'
+          '[storeCustodianBackupShare] Did not receive backup method as a string'
         )
       }
 

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -403,11 +403,15 @@ class MobileService {
         (backupShare) => backupShare.share
       )
 
+      const legacyBackupShare = user.custodianBackupShares.find(
+        (backupShare) => backupShare.backupMethod === 'UNKNOWN'
+      )
+
       // Return the custodian backup shares for the user.
       console.info(
         `Successfully responded with custodian backup shares for client ${clientId}`
       )
-      res.status(200).json({ backupShares })
+      res.status(200).json({ backupShare: legacyBackupShare })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -403,15 +403,16 @@ class MobileService {
         (backupShare) => backupShare.share
       )
 
-      const legacyBackupShare = user.custodianBackupShares.find(
-        (backupShare) => backupShare.backupMethod === 'UNKNOWN'
-      )?.share
+      // const legacyBackupShare = user.custodianBackupShares.find(
+      //   (backupShare) => backupShare.backupMethod === 'UNKNOWN'
+      // )?.share
 
       // Return the custodian backup shares for the user.
       console.info(
         `Successfully responded with custodian backup shares for client ${clientId}`
       )
-      res.status(200).json({ backupShare: legacyBackupShare })
+      // res.status(200).json({ backupShare: legacyBackupShare })
+      res.status(200).json({ backupShares })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -405,7 +405,7 @@ class MobileService {
 
       const legacyBackupShare = user.custodianBackupShares.find(
         (backupShare) => backupShare.backupMethod === 'UNKNOWN'
-      )
+      )?.share
 
       // Return the custodian backup shares for the user.
       console.info(

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -298,6 +298,7 @@ class MobileService {
    * Store the custodian backup share for a user.
    */
   async storeCustodianBackupShare(req: any, res: any): Promise<void> {
+    console.log('req.body', req.body)
     try {
       // Obtain the clientId from the request body.
       const clientId = req.body['clientId']

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -1,6 +1,6 @@
 import { CUSTODIAN_API_KEY } from '../config'
 import { isAddress } from 'ethers/lib/utils'
-import { PrismaClient, User } from '@prisma/client'
+import { BackupMethod, PrismaClient, User } from '@prisma/client'
 import { Request, Response } from 'express'
 import {
   EntityNotFoundError,
@@ -221,27 +221,43 @@ class MobileService {
   }
 
   /*
-   * Store the cipher text in the portalEx database.
+   * Store the client backup share for a user.
    */
-  async storeCipherText(req: any, res: any): Promise<void> {
+  async storeClientBackupShare(req: any, res: any): Promise<void> {
     try {
-      const exchangeUserId = Number(req.params['exchangeUserId'])
-      const user = await this.getUserByExchangeId(exchangeUserId)
+      const backupMethod = req.body['backupMethod'] || 'UNKNOWN'
       const cipherText = String(req.body['cipherText'])
+      const exchangeUserId = Number(req.params['exchangeUserId'])
+
+      const user = await this.getUserByExchangeId(exchangeUserId)
 
       if (!cipherText) {
         throw new Error('Client did not send the cipher text')
       }
 
-      await this.prisma.user.update({
+      // Remove any existing client backup shares for this backup method.
+      await this.prisma.clientBackupShare.deleteMany({
         where: {
-          id: user.id,
-        },
-        data: {
-          cipherText,
+          backupMethod,
+          userId: user.id,
         },
       })
-      res.status(200).json({ message: 'Successfully stored cipher text' })
+
+      // Store the client backup share.
+      await this.prisma.clientBackupShare.create({
+        data: {
+          backupMethod,
+          cipherText,
+          userId: user.id,
+        },
+      })
+
+      console.info(
+        `Successfully stored client backup share for user ${exchangeUserId}`
+      )
+      res
+        .status(200)
+        .json({ message: 'Successfully stored client backup share' })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })
@@ -249,18 +265,21 @@ class MobileService {
   }
 
   /*
-   * Get the org share from the portalEx database for the specific user.
+   * Get the client backup share for a user.
    */
-  async getOrgShare(req: any, res: any): Promise<void> {
+  async getClientBackupShare(req: any, res: any): Promise<void> {
     try {
       const exchangeUserId = Number(req.params['exchangeUserId'])
+      const backupMethod = req.query.backupMethod || 'UNKNOWN'
+
       const user = await this.getUserByExchangeId(exchangeUserId)
 
-      if (!user.backupShare) {
-        throw new Error('User does not have a stored org share')
-      }
+      // Attempt to find the client backup share for the specified backup method.
+      const cipherText = user.clientBackupShares?.find(
+        (backupShare) => backupShare.backupMethod === backupMethod
+      )
 
-      res.status(200).json({ orgShare: user.backupShare })
+      res.status(200).json({ cipherText })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })
@@ -268,57 +287,60 @@ class MobileService {
   }
 
   /*
-   * Get the cipher text from the portalEx database.
+   * Store the custodian backup share for a user.
    */
-  async getCipherText(req: any, res: any): Promise<void> {
+  async storeCustodianBackupShare(req: any, res: any): Promise<void> {
     try {
-      const exchangeUserId = Number(req.params['exchangeUserId'])
-      const user = await this.getUserByExchangeId(exchangeUserId)
-
-      if (!user.cipherText) {
-        throw new Error('User does not have a stored cipher text')
-      }
-
-      res.status(200).json({ cipherText: user.cipherText })
-    } catch (error) {
-      console.error(error)
-      res.status(500).json({ message: 'Internal server error' })
-    }
-  }
-
-  /*
-   * Store the backup Share in the portalEx database.
-   */
-  async storeBackupShare(req: any, res: any): Promise<void> {
-    try {
+      // Obtain the clientId from the request body.
       const clientId = req.body['clientId']
-      const backupShare = String(req.body['share'])
+      if (!clientId) {
+        console.error('[storeCustodianBackupShare] Did not receive clientId')
+        throw new Error('[storeCustodianBackupShare] Did not receive clientId')
+      }
       console.info(`Storing backup share for client ${clientId}`)
 
-      if (!clientId) {
-        console.error('[storeBackupShare] Did not receive clientId')
-        throw new Error('[storeBackupShare] Did not receive clientId')
+      // Obtain the custodian backup share from the request body.
+      const share = String(req.body['share'])
+      if (!share) {
+        console.error(
+          '[storeCustodianBackupShare] Did not receive backup share'
+        )
+        throw new Error(
+          '[storeCustodianBackupShare] Did not receive backup share'
+        )
       }
-      if (!backupShare) {
-        console.error('[storeBackupShare] Did not receive backup share')
-        throw new Error('[storeBackupShare] Did not receive backup share')
+
+      const backupMethod = req.body['backupMethod'] || 'UNKNOWN'
+      if (!backupMethod || !(backupMethod in BackupMethod)) {
+        console.error(
+          '[storeCustodianBackupShare] Received invalid backup method'
+        )
+        throw new Error(
+          '[storeCustodianBackupShare] Received invalid backup method'
+        )
       }
 
       const user = await this.getUserByClientId(clientId)
 
-      await this.prisma.user.update({
+      // Remove any existing custodian backup shares for this backup method.
+      await this.prisma.custodianBackupShare.deleteMany({
         where: {
-          id: user.id,
+          backupMethod,
+          userId: user.id,
         },
+      })
+
+      // Store the custodian backup share.
+      await this.prisma.custodianBackupShare.create({
         data: {
-          backupShare,
+          backupMethod,
+          share,
+          userId: user.id,
         },
       })
 
       console.info(`Successfully stored backup share for client ${clientId}`)
-      res
-        .status(200)
-        .json({ message: `Successfully stored backup share for client` })
+      res.status(200).json({ message: 'Successfully stored backup share' })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })
@@ -326,29 +348,50 @@ class MobileService {
   }
 
   /*
-   * Get the backup Share from the portalEx database.
+   * Get the custodian backup share for a user.
    */
-  async getBackupShare(req: any, res: any): Promise<void> {
+  async getCustodianBackupShare(req: any, res: any): Promise<void> {
+    try {
+      const exchangeUserId = Number(req.params['exchangeUserId'])
+      const backupMethod = req.query.backupMethod || 'UNKNOWN'
+
+      const user = await this.getUserByExchangeId(exchangeUserId)
+
+      // Attempt to find the custodian backup share for the specified backup method.
+      const orgShare = user.custodianBackupShares?.find(
+        (backupShare) => backupShare.backupMethod === backupMethod
+      )
+
+      res.status(200).json({ orgShare })
+    } catch (error) {
+      console.error(error)
+      res.status(500).json({ message: 'Internal server error' })
+    }
+  }
+
+  /*
+   * Get the custodian backup shares for a user.
+   */
+  async getCustodianBackupShares(req: any, res: any): Promise<void> {
     try {
       const clientId = req.body['clientId']
       if (!clientId) {
-        console.error('[getBackupShare] Did not receive clientId')
-        throw new Error('[getBackupShare] Did not receive clientId')
+        console.error('[getCustodianBackupShares] Did not receive clientId')
+        throw new Error('[getCustodianBackupShares] Did not receive clientId')
       }
 
       const user = await this.getUserByClientId(clientId)
-      if (!user?.backupShare) {
-        console.info(
-          `User ${clientId} does not have a backup share stored in the database`
-        )
-        res.status(400).json({ message: 'User does not have a backup share' })
-        return
-      }
 
-      console.info(
-        `Successfully responded with backup share for client ${clientId}`
+      // Obtain the custodian backup shares for the user.
+      const backupShares = user.custodianBackupShares.map(
+        (backupShare) => backupShare.share
       )
-      res.status(200).json({ backupShare: user.backupShare })
+
+      // Return the custodian backup shares for the user.
+      console.info(
+        `Successfully responded with custodian backup shares for client ${clientId}`
+      )
+      res.status(200).json({ backupShares })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })
@@ -510,6 +553,10 @@ class MobileService {
     console.info(`Querying for userId: ${exchangeUserId}`)
     const user = await this.prisma.user.findUnique({
       where: { exchangeUserId },
+      include: {
+        clientBackupShares: true,
+        custodianBackupShares: true,
+      },
     })
 
     if (!user) {
@@ -526,6 +573,10 @@ class MobileService {
     console.info(`Querying for userId: ${clientId}`)
     const user = await this.prisma.user.findUnique({
       where: { clientId },
+      include: {
+        clientBackupShares: true,
+        custodianBackupShares: true,
+      },
     })
 
     if (!user) {

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -358,11 +358,11 @@ class MobileService {
       const user = await this.getUserByExchangeId(exchangeUserId)
 
       // Attempt to find the custodian backup share for the specified backup method.
-      const orgShare = user.custodianBackupShares?.find(
+      const custodianBackupShare = user.custodianBackupShares?.find(
         (backupShare) => backupShare.backupMethod === backupMethod
       )
 
-      res.status(200).json({ orgShare })
+      res.status(200).json({ orgShare: custodianBackupShare?.share })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -1,6 +1,6 @@
 import { CUSTODIAN_API_KEY } from '../config'
 import { isAddress } from 'ethers/lib/utils'
-import { BackupMethod, PrismaClient, User } from '@prisma/client'
+import { PrismaClient, User } from '@prisma/client'
 import { Request, Response } from 'express'
 import {
   EntityNotFoundError,
@@ -225,7 +225,7 @@ class MobileService {
    */
   async storeClientBackupShare(req: any, res: any): Promise<void> {
     try {
-      const backupMethod = req.body['backupMethod'] || 'UNKNOWN'
+      const backupMethod = req.body['backupMethod']
       const cipherText = String(req.body['cipherText'])
       const exchangeUserId = Number(req.params['exchangeUserId'])
 
@@ -270,13 +270,13 @@ class MobileService {
   async getClientBackupShare(req: any, res: any): Promise<void> {
     try {
       const exchangeUserId = Number(req.params['exchangeUserId'])
-      const backupMethod = req.query.backupMethod || 'UNKNOWN'
+      const backupMethod = req.query.backupMethod
 
       const user = await this.getUserByExchangeId(exchangeUserId)
 
       // Attempt to find the client backup share for the specified backup method.
       const cipherText = user.clientBackupShares?.find(
-        (backupShare) => backupShare.backupMethod === backupMethod
+        (clientBackupShare) => clientBackupShare.backupMethod === backupMethod
       )
 
       res.status(200).json({ cipherText })
@@ -310,8 +310,8 @@ class MobileService {
         )
       }
 
-      const backupMethod = req.body['backupMethod'] || 'UNKNOWN'
-      if (!backupMethod || !(backupMethod in BackupMethod)) {
+      const backupMethod = req.body['backupMethod']
+      if (!backupMethod) {
         console.error(
           '[storeCustodianBackupShare] Received invalid backup method'
         )
@@ -353,7 +353,7 @@ class MobileService {
   async getCustodianBackupShare(req: any, res: any): Promise<void> {
     try {
       const exchangeUserId = Number(req.params['exchangeUserId'])
-      const backupMethod = req.query.backupMethod || 'UNKNOWN'
+      const backupMethod = req.query.backupMethod
 
       const user = await this.getUserByExchangeId(exchangeUserId)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,46 +941,46 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@prisma/client@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.7.0.tgz#c29dd9a16e100902eb2d2443d90fee2482d2aeac"
-  integrity sha512-cZmglCrfNbYpzUtz7HscVHl38e9CrUs31nrVoGUK1nIPXGgt8hT4jj2s657UXcNdQ/jBUxDgGmHyu2Nyrq1txg==
+"@prisma/client@^5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.8.1.tgz#7815ec51c0ca2a6de219c02e7846701ae3baf240"
+  integrity sha512-xQtMPfbIwLlbm0VVIVQY2yqQVOxPwRQhvIp7Z3m2900g1bu/zRHKhYZJQWELqmjl6d8YwBy0K2NvMqh47v1ubw==
 
-"@prisma/debug@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.7.0.tgz#abdb2060be4fe819e73e2683cf1b039841566198"
-  integrity sha512-tZ+MOjWlVvz1kOEhNYMa4QUGURY+kgOUBqLHYIV8jmCsMuvA1tWcn7qtIMLzYWCbDcQT4ZS8xDgK0R2gl6/0wA==
+"@prisma/debug@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.8.1.tgz#704daa36919b0fc4d227260ecebfa1c94b155b07"
+  integrity sha512-tjuw7eA0Us3T42jx9AmAgL58rzwzpFGYc3R7Y4Ip75EBYrKMBA1YihuWMcBC92ILmjlQ/u3p8VxcIE0hr+fZfg==
 
-"@prisma/engines-version@5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9":
-  version "5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9.tgz#777827898f1bfe6a76b17fbe7d9600cf543c4cc1"
-  integrity sha512-V6tgRVi62jRwTm0Hglky3Scwjr/AKFBFtS+MdbsBr7UOuiu1TKLPc6xfPiyEN1+bYqjEtjxwGsHgahcJsd1rNg==
+"@prisma/engines-version@5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2":
+  version "5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2.tgz#f600a45afc4cf0c0356b6ed90add6050fa3f3239"
+  integrity sha512-f5C3JM3l9yhGr3cr4FMqWloFaSCpNpMi58Om22rjD2DOz3owci2mFdFXMgnAGazFPKrCbbEhcxdsRfspEYRoFQ==
 
-"@prisma/engines@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.7.0.tgz#a32e232819b66bd9dee7500b455781742dc54b2f"
-  integrity sha512-TkOMgMm60n5YgEKPn9erIvFX2/QuWnl3GBo6yTRyZKk5O5KQertXiNnrYgSLy0SpsKmhovEPQb+D4l0SzyE7XA==
+"@prisma/engines@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.8.1.tgz#b850751f5bf7d5e570b9fe16cefdc2b1fd2c02c3"
+  integrity sha512-TJgYLRrZr56uhqcXO4GmP5be+zjCIHtLDK20Cnfg+o9d905hsN065QOL+3Z0zQAy6YD31Ol4u2kzSfRmbJv/uA==
   dependencies:
-    "@prisma/debug" "5.7.0"
-    "@prisma/engines-version" "5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9"
-    "@prisma/fetch-engine" "5.7.0"
-    "@prisma/get-platform" "5.7.0"
+    "@prisma/debug" "5.8.1"
+    "@prisma/engines-version" "5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2"
+    "@prisma/fetch-engine" "5.8.1"
+    "@prisma/get-platform" "5.8.1"
 
-"@prisma/fetch-engine@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.7.0.tgz#7d2795828b692b02707e7ab6876f6227a68fc309"
-  integrity sha512-zIn/qmO+N/3FYe7/L9o+yZseIU8ivh4NdPKSkQRIHfg2QVTVMnbhGoTcecbxfVubeTp+DjcbjS0H9fCuM4W04w==
+"@prisma/fetch-engine@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.8.1.tgz#38bb92f1fbd3669340a3cc49fce403ab4df671dd"
+  integrity sha512-+bgjjoSFa6uYEbAPlklfoVSStOEfcpheOjoBoNsNNSQdSzcwE2nM4Q0prun0+P8/0sCHo18JZ9xqa8gObvgOUw==
   dependencies:
-    "@prisma/debug" "5.7.0"
-    "@prisma/engines-version" "5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9"
-    "@prisma/get-platform" "5.7.0"
+    "@prisma/debug" "5.8.1"
+    "@prisma/engines-version" "5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2"
+    "@prisma/get-platform" "5.8.1"
 
-"@prisma/get-platform@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.7.0.tgz#eb81011f537c2d10c0225278cd5165a82d0b57c8"
-  integrity sha512-ZeV/Op4bZsWXuw5Tg05WwRI8BlKiRFhsixPcAM+5BKYSiUZiMKIi713tfT3drBq8+T0E1arNZgYSA9QYcglWNA==
+"@prisma/get-platform@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.8.1.tgz#8cd450b65a52a5a6ed5b2f52457136a492c0f251"
+  integrity sha512-wnA+6HTFcY+tkykMokix9GiAkaauPC5W/gg0O5JB0J8tCTNWrqpnQ7AsaGRfkYUbeOIioh6woDjQrGTTRf1Zag==
   dependencies:
-    "@prisma/debug" "5.7.0"
+    "@prisma/debug" "5.8.1"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.6"
@@ -3903,12 +3903,12 @@ pretty-format@^27.0.0, pretty-format@^27.5.1:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-prisma@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.7.0.tgz#3c1c56d392b5d1137de954edefa4533fa092663e"
-  integrity sha512-0rcfXO2ErmGAtxnuTNHQT9ztL0zZheQjOI/VNJzdq87C3TlGPQtMqtM+KCwU6XtmkoEr7vbCQqA7HF9IY0ST+Q==
+prisma@^5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.8.1.tgz#1f101793a8831c0719dfbed5f85a96ea4888c9d3"
+  integrity sha512-N6CpjzECnUHZ5beeYpDzkt2rYpEdAeqXX2dweu6BoQaeYkNZrC/WJHM+5MO/uidFHTak8QhkPKBWck1o/4MD4A==
   dependencies:
-    "@prisma/engines" "5.7.0"
+    "@prisma/engines" "5.8.1"
 
 promise-limit@^2.7.0:
   version "2.7.0"


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR updates `/webhook/fetch` to return back `backupShares: string[]`. It also updates the schema models to include `ClientBackupShare` and `CustodianBackupShare`. It retains current functionality by defaulting new `backupMethod` query params or request body properties to `UNKNOWN`.

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: Yes, changes return value for `/backup/fetch` as `backupShares` instead of `backupShare`.
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: Updated
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
