### PR TITLE
Find legacy backup share if no backup method provided AND if unable t…

### DIFF
--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -279,15 +279,28 @@ class MobileService {
         (clientBackupShare) => clientBackupShare.backupMethod === backupMethod
       )
 
-      // If no client backup share was found, return a 404.
-      if (!clientBackupShare) {
-        console.error(
-          `[getClientBackupShare] Could not find client backup share for user ${exchangeUserId} with backup method ${backupMethod}]`
-        )
-        res.status(404).json({ message: 'Client backup share not found' })
+      // If client backup share was found, return the cipher text.
+      if (clientBackupShare) {
+        res.status(200).json({ cipherText: clientBackupShare?.cipherText })
+        return
       }
 
-      res.status(200).json({ cipherText: clientBackupShare?.cipherText })
+      // If no client backup share was found, find the backup share with the legacy backup method.
+      const legacyBackupShare = user.clientBackupShares.find(
+        (clientBackupShare) => clientBackupShare.backupMethod === 'UNKNOWN'
+      )
+
+      // If a legacy backup share was found, return the cipher text.
+      if (legacyBackupShare) {
+        res.status(200).json({ cipherText: legacyBackupShare?.cipherText })
+        return
+      }
+
+      // If no client backup share was found, return a 404.
+      console.error(
+        `[getClientBackupShare] Could not find client backup share for user ${exchangeUserId} with backup method ${backupMethod}]`
+      )
+      res.status(404).json({ message: 'Client backup share not found' })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR ensures we find legacy backup share if no backup method provided AND if we're unable to find backup share by the provided backup method (indicating that it may be the legacy backup share).

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
