### PR TITLE
Mirror get client backup share logic

### DIFF
--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -380,18 +380,33 @@ class MobileService {
 
       // Attempt to find the custodian backup share for the specified backup method.
       const custodianBackupShare = user.custodianBackupShares?.find(
-        (backupShare) => backupShare.backupMethod === backupMethod
+        (custodianBackupShare) =>
+          custodianBackupShare.backupMethod === backupMethod
       )
 
-      // If no custodian backup share was found, return a 404.
-      if (!custodianBackupShare) {
-        console.error(
-          `[getCustodianBackupShare] Could not find custodian backup share for user ${exchangeUserId} with backup method ${backupMethod}]`
-        )
-        res.status(404).json({ message: 'Custodian backup share not found' })
+      // If custodian backup share was found, return the cipher text.
+      if (custodianBackupShare) {
+        res.status(200).json({ orgShare: custodianBackupShare?.share })
+        return
       }
 
-      res.status(200).json({ orgShare: custodianBackupShare?.share })
+      // If no custodian backup share was found, find the backup share with the legacy backup method.
+      const legacyBackupShare = user.custodianBackupShares.find(
+        (custodianBackupShare) =>
+          custodianBackupShare.backupMethod === 'UNKNOWN'
+      )
+
+      // If a legacy backup share was found, return the cipher text.
+      if (legacyBackupShare) {
+        res.status(200).json({ orgShare: legacyBackupShare?.share })
+        return
+      }
+
+      // If no custodian backup share was found, return a 404.
+      console.error(
+        `[getCustodianBackupShare] Could not find custodian backup share for user ${exchangeUserId} with backup method ${backupMethod}]`
+      )
+      res.status(404).json({ message: 'Custodian backup share not found' })
     } catch (error) {
       console.error(error)
       res.status(500).json({ message: 'Internal server error' })


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR ensures we find legacy backup share if no backup method is provided AND if we're unable to find backup share by the provided backup method (indicating that it may be the legacy backup share) for the org-share endpoint.

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
