### PR TITLE
Add backupSharePairId to ClBS and CuBS

### DIFF
--- a/prisma/migrations/20240325232749_add_backup_share_pair_id_to_shares/migration.sql
+++ b/prisma/migrations/20240325232749_add_backup_share_pair_id_to_shares/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX "ClientBackupShare_userId_backupMethod_key";
+
+-- DropIndex
+DROP INDEX "CustodianBackupShare_userId_backupMethod_key";
+
+-- AlterTable
+ALTER TABLE "ClientBackupShare" ADD COLUMN     "backupSharePairId" TEXT;
+
+-- AlterTable
+ALTER TABLE "CustodianBackupShare" ADD COLUMN     "backupSharePairId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,27 +8,25 @@ datasource db {
 }
 
 model ClientBackupShare {
-  backupMethod String       @default("UNKNOWN")
-  createdAt    DateTime     @default(now())
-  id           String       @id @default(cuid())
-  cipherText   String
-  userId       Int
+  backupMethod      String  @default("UNKNOWN")
+  backupSharePairId String?
+  createdAt         DateTime @default(now())
+  id                String   @id @default(cuid())
+  cipherText        String
+  userId            Int
 
   user User @relation(fields: [userId], references: [id])
-
-  @@unique([userId, backupMethod])
 }
 
 model CustodianBackupShare {
-  backupMethod String       @default("UNKNOWN")
-  createdAt    DateTime     @default(now())
-  id           String       @id @default(cuid())
-  share        String
-  userId       Int
+  backupMethod      String  @default("UNKNOWN")
+  backupSharePairId String?
+  createdAt         DateTime @default(now())
+  id                String   @id @default(cuid())
+  share             String
+  userId            Int
 
   user User @relation(fields: [userId], references: [id])
-
-  @@unique([userId, backupMethod])
 }
 
 model ExchangeBalance {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR updates `ClientBackupShare` and `CustodianBackupShare` models to not have a unique constraint by backupMethod + userId. It also updates the models with a new property `backupSharePairId` that is optional.

It also updates all getter and setter methods for client/custodian backup shares using the new `backupSharePairId` property.

Before merging this I'd like a review, even before merging to staging, since it includes a migration that will be difficult to rollback.

One callout is that **WE WILL NOT BE DELETING BACKUP SHARES ANYMORE** when storing a new backup share (beforehand we would find all backup shares with the same backup method and delete them, to ensure you only have 1 backup share with that backup method).

## Details

### Code
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
