### PR TITLE
Kelsonic/fix dupes

### DIFF
--- a/prisma/migrations/20240325232749_add_backup_share_pair_id_to_shares/migration.sql
+++ b/prisma/migrations/20240325232749_add_backup_share_pair_id_to_shares/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX "ClientBackupShare_userId_backupMethod_key";
+
+-- DropIndex
+DROP INDEX "CustodianBackupShare_userId_backupMethod_key";
+
+-- AlterTable
+ALTER TABLE "ClientBackupShare" ADD COLUMN     "backupSharePairId" TEXT;
+
+-- AlterTable
+ALTER TABLE "CustodianBackupShare" ADD COLUMN     "backupSharePairId" TEXT;

--- a/prisma/migrations/20240328165028_make_shares_unique_by_user_id_backup_method_backup_share_pair_id/migration.sql
+++ b/prisma/migrations/20240328165028_make_shares_unique_by_user_id_backup_method_backup_share_pair_id/migration.sql
@@ -1,0 +1,27 @@
+-- Remove duplicates and keep the oldest record.
+DELETE FROM "ClientBackupShare"
+WHERE "id" IN (
+  SELECT "id"
+  FROM (
+    SELECT "id", ROW_NUMBER() OVER(PARTITION BY "userId", "backupMethod", "backupSharePairId" ORDER BY "createdAt" DESC) AS rnum
+    FROM "ClientBackupShare"
+  ) t
+  WHERE t.rnum > 1
+);
+
+-- Remove duplicates and keep the oldest record.
+DELETE FROM "CustodianBackupShare"
+WHERE "id" IN (
+  SELECT "id"
+  FROM (
+    SELECT "id", ROW_NUMBER() OVER(PARTITION BY "userId", "backupMethod", "backupSharePairId" ORDER BY "createdAt" DESC) AS rnum
+    FROM "CustodianBackupShare"
+  ) t
+  WHERE t.rnum > 1
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ClientBackupShare_userId_backupMethod_backupSharePairId_key" ON "ClientBackupShare"("userId", "backupMethod", "backupSharePairId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CustodianBackupShare_userId_backupMethod_backupSharePairId_key" ON "CustodianBackupShare"("userId", "backupMethod", "backupSharePairId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,27 +8,25 @@ datasource db {
 }
 
 model ClientBackupShare {
-  backupMethod String       @default("UNKNOWN")
-  createdAt    DateTime     @default(now())
-  id           String       @id @default(cuid())
-  cipherText   String
-  userId       Int
+  backupMethod      String  @default("UNKNOWN")
+  backupSharePairId String?
+  createdAt         DateTime @default(now())
+  id                String   @id @default(cuid())
+  cipherText        String
+  userId            Int
 
   user User @relation(fields: [userId], references: [id])
-
-  @@unique([userId, backupMethod])
 }
 
 model CustodianBackupShare {
-  backupMethod String       @default("UNKNOWN")
-  createdAt    DateTime     @default(now())
-  id           String       @id @default(cuid())
-  share        String
-  userId       Int
+  backupMethod      String  @default("UNKNOWN")
+  backupSharePairId String?
+  createdAt         DateTime @default(now())
+  id                String   @id @default(cuid())
+  share             String
+  userId            Int
 
   user User @relation(fields: [userId], references: [id])
-
-  @@unique([userId, backupMethod])
 }
 
 model ExchangeBalance {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,8 @@ model ClientBackupShare {
   userId            Int
 
   user User @relation(fields: [userId], references: [id])
+
+  @@unique([userId, backupMethod, backupSharePairId])
 }
 
 model CustodianBackupShare {
@@ -27,6 +29,8 @@ model CustodianBackupShare {
   userId            Int
 
   user User @relation(fields: [userId], references: [id])
+
+  @@unique([userId, backupMethod, backupSharePairId])
 }
 
 model ExchangeBalance {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR is two-fold:
1. A commit was sent to staging that removed a unique constraint for client + backup shares (userId + backupMethod).
2. A commit that introduces a new constraint for client + backup shares (userId + backupMethod + backupSharePairId) and also adds the optional `backupSharePairId` field to both share models.

The migration will also delete all Portalex custodian + client backup shares that are considered duplicates by userId + backupMethod + backupSharePairId (it will leave the oldest share).

All duplicates grouped by unique constraint (userId + backupMethod + backupSharePairId)
<img width="846" alt="image" src="https://github.com/portal-hq/portalex/assets/12773166/6fe10889-abab-4cf0-ad16-4c1c959e12f7">

Custodian backup share duplicates:
<img width="1319" alt="image" src="https://github.com/portal-hq/portalex/assets/12773166/1f868202-590f-4f54-ad33-befde91304b3">

Client backup share duplicates (so few because e2e tests store client backup shares locally, so this is just from SDK testing on staging since the removal of the constraint happened):
<img width="1320" alt="image" src="https://github.com/portal-hq/portalex/assets/12773166/6ffa7a1e-f806-4faf-b077-53fd138b0dcc">


## Details

### Code
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
