### PR TITLE
Add clientId and username to /signup and /login endpoints

### DIFF
--- a/src/libs/PortalApi.ts
+++ b/src/libs/PortalApi.ts
@@ -103,7 +103,7 @@ class PortalApi {
 
     logger.info(`Prepare Eject Response: ${response.data}`)
 
-    return response.data as string
+    return response.data
   }
 
   /**

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -81,8 +81,10 @@ class MobileService {
       }
 
       res.status(200).json({
-        exchangeUserId: user.exchangeUserId,
         clientApiKey: user.clientApiKey,
+        clientId: user.clientId,
+        exchangeUserId: user.exchangeUserId,
+        username: user.username,
       })
     } catch (error) {
       if (error instanceof HttpError) {
@@ -170,8 +172,10 @@ class MobileService {
 
       logger.info(`Successfully signed up ${exchangeUserId}`)
       res.status(200).json({
-        exchangeUserId: user.exchangeUserId,
         clientApiKey: user.clientApiKey,
+        clientId: user.clientId,
+        exchangeUserId: user.exchangeUserId,
+        username: user.username,
       })
     } catch (error: any) {
       if (error instanceof HttpError) {
@@ -230,7 +234,10 @@ class MobileService {
         throw new MissingParameterError('walletId')
       }
 
-      const prepareEjectResponse = await this.portalApi.prepareEject(user.clientId, walletId)
+      const prepareEjectResponse = await this.portalApi.prepareEject(
+        user.clientId,
+        walletId,
+      )
 
       res.status(200).send(prepareEjectResponse)
     } catch (error: any) {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR adds `clientId` and `username` to both the `/signup` and `/login` endpoint responses. Tested on web + Swift + Kotlin + RN, no typing issues 👌 

## Details

### Code
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
