### PR TITLE
Create sim alert webhook event failure endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -270,6 +270,13 @@ app.post(
   },
 )
 
+app.post(
+  '/alerts/webhook/events/simulate-failure',
+  (req: Request, res: Response) => {
+    mobileService.simulateAlertWebhookEventFailure(req, res)
+  },
+)
+
 app.get(
   '/alerts/webhook/events/:alertWebhookEventId',
   async (req: Request, res: Response) => {

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -854,6 +854,19 @@ class MobileService {
   }
 
   /*
+   * Simulate a failure of an alert webhook event
+   */
+  simulateAlertWebhookEventFailure(req: Request, res: Response): void {
+    logger.info(
+      `[simulateAlertWebhookEventFailure] Simulating alert webhook event failure`,
+      {
+        requestBody: req.body,
+      },
+    )
+    res.status(400).json({ message: 'Simulated alert webhook event failure' })
+  }
+
+  /*
    * Get alert webhook event by id
    */
   async getAlertWebhookEvent(req: Request, res: Response): Promise<void> {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR builds a new endpoint that just simulates an alert webhook event failure for testing purposes.

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/966f7e9a-e649-43db-8c48-faa40a115f77" />

## Details

### Code
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
