### PR TITLE
Update ambiguous /prepare-eject endpoint naming to /enable-eject

### DIFF
--- a/src/libs/PortalApi.ts
+++ b/src/libs/PortalApi.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, isAxiosError } from 'axios'
+import axios, { AxiosError, AxiosResponse, isAxiosError } from 'axios'
 
 import { PORTAL_API_URL } from '../config'
 import { logger } from '../libs/logger'
@@ -78,7 +78,44 @@ class PortalApi {
       })
   }
 
-  async prepareEject(clientId: string, walletId: string): Promise<string> {
+  async enableEject(
+    clientId: string,
+    walletId: string,
+  ): Promise<{ ejectableUntil: string }> {
+    const headers = {
+      Authorization: `Bearer ${this.apiKey}`,
+    }
+
+    let response: AxiosResponse<{ ejectableUntil: string }>
+    try {
+      response = await axios.patch<{ ejectableUntil: string }>(
+        `${PORTAL_API_URL}/api/v3/custodians/me/clients/${clientId}/enable-eject`,
+        { walletId },
+        {
+          headers: headers,
+        },
+      )
+    } catch (error: any) {
+      const errorData = error.response?.data as {
+        error?: string
+      }
+      throw {
+        status: error.response?.status,
+        message: `Portal API Error: ${errorData.error}`,
+      }
+    }
+
+    logger.info(`Enable eject response`, {
+      responseData: response.data,
+    })
+
+    return response.data
+  }
+
+  async deprecated_enableEject(
+    clientId: string,
+    walletId: string,
+  ): Promise<string> {
     const headers = {
       Authorization: `Bearer ${this.apiKey}`,
     }
@@ -101,7 +138,7 @@ class PortalApi {
         }
       })
 
-    logger.info(`Prepare Eject Response: ${response.data}`)
+    logger.info(`Deprecated Enable Eject Response: ${response.data}`)
 
     return response.data
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -206,10 +206,18 @@ app.post(
   },
 )
 
+app.patch(
+  '/mobile/:exchangeUserId/enable-eject',
+  async (req: Request, res: Response) => {
+    await mobileService.enableEject(req, res)
+  },
+)
+
+// Deprecated
 app.post(
   '/mobile/:exchangeUserId/prepare-eject',
   async (req: Request, res: Response) => {
-    await mobileService.prepareEject(req, res)
+    await mobileService.deprecated_enableEject(req, res)
   },
 )
 

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -224,7 +224,7 @@ class MobileService {
     return user
   }
 
-  async prepareEject(req: Request, res: Response): Promise<void> {
+  async enableEject(req: Request, res: Response): Promise<void> {
     try {
       const exchangeUserId = Number(req.params['exchangeUserId'])
       const user = await this.getUserByExchangeId(exchangeUserId)
@@ -238,12 +238,43 @@ class MobileService {
         throw new MissingParameterError('walletId')
       }
 
-      const prepareEjectResponse = await this.portalApi.prepareEject(
+      const enableEjectResponse = await this.portalApi.enableEject(
         user.clientId,
         walletId,
       )
 
-      res.status(200).send(prepareEjectResponse)
+      res.status(200).send(enableEjectResponse)
+    } catch (error: any) {
+      if (error instanceof HttpError) {
+        res.status(error.HttpStatus).json({ message: error.message })
+        return
+      }
+
+      logger.error(error)
+      res.status(500).json({ message: error.message })
+    }
+  }
+
+  async deprecated_enableEject(req: Request, res: Response): Promise<void> {
+    try {
+      const exchangeUserId = Number(req.params['exchangeUserId'])
+      const user = await this.getUserByExchangeId(exchangeUserId)
+
+      if (!user.clientApiKey) {
+        throw new Error('User does not have a client api key')
+      }
+
+      const walletId = req.body['walletId'] as string
+      if (!walletId) {
+        throw new MissingParameterError('walletId')
+      }
+
+      const enableEjectResponse = await this.portalApi.deprecated_enableEject(
+        user.clientId,
+        walletId,
+      )
+
+      res.status(200).send(enableEjectResponse)
     } catch (error: any) {
       if (error instanceof HttpError) {
         res.status(error.HttpStatus).json({ message: error.message })


### PR DESCRIPTION
## Summary
This PR updates the `POST /prepare-eject` endpoint to `PATCH /enable-eject` to better align with the new endpoint names in connect-api from [this PR](https://github.com/portal-hq/connect-api/pull/1111).

## Details

### Code
- Documentation updated: No <!-- Yes|No|Pending -->

### Impact
- Breaking Changes: No <!-- Yes|No -->
- Performance impact: No <!-- Yes|No -->

### Testing
- Unit tests added/updated: No <!-- Yes|No -->
- E2E tests added/updated: No <!-- Yes|No -->

### Misc.
- Metrics, logs, or traces added/updated: No <!-- Yes|No -->
