### PR TITLE
Add eventType filter

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -65,3 +65,12 @@ export const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY || ''
 // Pre-sign Alert Webhook Event Types
 // ==============================
 export const PRE_SIGN_ALERT_WEBHOOK_EVENT_TYPES = ['PRE_SIGN_V1']
+
+// ==============================
+// Alert Webhook Event Types
+// ==============================
+export const ALERT_WEBHOOK_EVENT_TYPES = [
+  'EIP_155_TX_V1',
+  'SOLANA_TX_V1',
+  ...PRE_SIGN_ALERT_WEBHOOK_EVENT_TYPES,
+]

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -1135,7 +1135,10 @@ class MobileService {
           (alertWebhookEvent) => {
             return (alertWebhookEvent.event as any[]).some((event) => {
               return (event.nativeTransfers as any[]).some((transfer) => {
-                return transfer.toUserAccount === address
+                return (
+                  transfer.toUserAccount === address ||
+                  transfer.fromUserAccount === address
+                )
               })
             })
           },
@@ -1145,12 +1148,14 @@ class MobileService {
       logger.info(
         `[getAlertWebhookEventsByAddress] Successfully fetched alert webhook events`,
         {
+          address,
+          since,
+          limit,
+          eventType,
           unfilteredCount: alertWebhookEvents.length,
           unfilteredAlertWebhookEvents: alertWebhookEvents,
           filteredCount: filteredAlertWebhookEvents.length,
           filteredAlertWebhookEvents: filteredAlertWebhookEvents,
-          since,
-          limit,
         },
       )
 

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -1121,7 +1121,7 @@ class MobileService {
         whereClause,
       })
 
-      let alertWebhookEvents = await this.prisma.alertWebhookEvent.findMany({
+      const alertWebhookEvents = await this.prisma.alertWebhookEvent.findMany({
         where: whereClause,
         orderBy: {
           createdAt: 'desc',
@@ -1129,26 +1129,32 @@ class MobileService {
         take: limit,
       })
 
+      let filteredAlertWebhookEvents = alertWebhookEvents
       if (eventType === 'SOLANA_TX_V1') {
-        alertWebhookEvents = alertWebhookEvents.filter((alertWebhookEvent) => {
-          return (alertWebhookEvent.event as any[]).some((event) => {
-            return (event.nativeTransfers as any[]).some((transfer) => {
-              return transfer.toUserAccount === address
+        filteredAlertWebhookEvents = alertWebhookEvents.filter(
+          (alertWebhookEvent) => {
+            return (alertWebhookEvent.event as any[]).some((event) => {
+              return (event.nativeTransfers as any[]).some((transfer) => {
+                return transfer.toUserAccount === address
+              })
             })
-          })
-        })
+          },
+        )
       }
 
       logger.info(
         `[getAlertWebhookEventsByAddress] Successfully fetched alert webhook events`,
         {
-          count: alertWebhookEvents.length,
+          unfilteredCount: alertWebhookEvents.length,
+          unfilteredAlertWebhookEvents: alertWebhookEvents,
+          filteredCount: filteredAlertWebhookEvents.length,
+          filteredAlertWebhookEvents: filteredAlertWebhookEvents,
           since,
           limit,
         },
       )
 
-      res.status(200).json({ alertWebhookEvents })
+      res.status(200).json({ alertWebhookEvents: filteredAlertWebhookEvents })
     } catch (error) {
       logger.error(
         `[getAlertWebhookEventsByAddress] Error fetching alert webhook events`,


### PR DESCRIPTION
## Summary
This PR adds an `eventType` filter (one of: `SOLANA_TX_V1`, `EIP_155_TX_V1`, etc) to allow our e2e tests to easily get just the historical alert webhook event records they need to monitor.

## Details

### Code
- Documentation updated: No <!-- Yes|No|Pending -->

### Impact
- Breaking Changes: No <!-- Yes|No -->
- Performance impact: No <!-- Yes|No -->

### Testing
- Unit tests added/updated: No <!-- Yes|No -->
- E2E tests added/updated: No <!-- Yes|No -->

### Misc.
- Metrics, logs, or traces added/updated: No <!-- Yes|No -->
